### PR TITLE
Add message filtering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target/
 .idea
+.vscode/settings.json

--- a/README.md
+++ b/README.md
@@ -130,6 +130,19 @@ Default value: `5000`
 }
 ```
 
+### filteredWords
+
+**Not** required.
+
+All messages are checked to see if they contain any of these strings. If there is a match, the message is discarded.
+Default value: `empty`
+
+```json
+{
+  "filteredWords": ["sshd", "[UFW ALLOW]"]
+}
+```
+
 ## Register with Systemd
 
 1. Create a service file under `/etc/systemd/system/`. For example: `/etc/systemd/system/SystemdLogTracker.service`

--- a/src/main/java/com/tomacheese/systemdlogtracker/Config.java
+++ b/src/main/java/com/tomacheese/systemdlogtracker/Config.java
@@ -1,5 +1,6 @@
 package com.tomacheese.systemdlogtracker;
 
+import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -15,6 +16,7 @@ public class Config {
     private String discordWebhookUrl;
     private String slackWebhookUrl;
     private String arguments = "-a -o cat -f -n 0";
+    private String[] filteredWords = new String[0];
     private long sendInterval = 5000;
 
     public Config(Path path) {
@@ -23,6 +25,17 @@ public class Config {
         if (!bool) {
             System.exit(1);
         }
+    }
+
+    public static String[] toStringArray(JSONArray array) {
+        if(array==null)
+            return null;
+    
+        String[] arr=new String[array.length()];
+        for(int i=0; i<arr.length; i++) {
+            arr[i]=array.optString(i);
+        }
+        return arr;
     }
 
     public boolean load() {
@@ -56,6 +69,7 @@ public class Config {
             }
 
             arguments = object.has("arguments") ? object.getString("arguments") : arguments;
+            filteredWords = object.has("filteredWords") ? toStringArray(object.getJSONArray("filteredWords")) : filteredWords;
             sendInterval = object.has("sendInterval") ? object.getLong("sendInterval") : sendInterval;
         } catch (JSONException e) {
             System.out.println("[ERROR] The setting information could not be read normally.");
@@ -86,6 +100,10 @@ public class Config {
 
     public String getJournalArguments() {
         return arguments;
+    }
+
+    public String[] getFilteredWords() {
+        return filteredWords;
     }
 
     public long getSendInterval() {

--- a/src/main/java/com/tomacheese/systemdlogtracker/Main.java
+++ b/src/main/java/com/tomacheese/systemdlogtracker/Main.java
@@ -27,9 +27,18 @@ public class Main {
         CompletableFuture.delayedExecutor(1, TimeUnit.SECONDS).execute(new Sender());
     }
 
+    public static boolean containsItemFromArray(String inputString, String[] items) {
+        return Arrays.stream(items).anyMatch(inputString::contains);
+    }
+
     public static void SendMessage(String text) {
         if (text.length() >= 2000) {
             System.out.println("[ERROR] line message too long: " + text.length() + "\n" + text);
+            return;
+        }
+        
+        if (containsItemFromArray(text, config.getFilteredWords())) {
+            System.out.println("Message matched filtered word, ignoring");
             return;
         }
         messages.add(text);

--- a/src/main/java/com/tomacheese/systemdlogtracker/Sender.java
+++ b/src/main/java/com/tomacheese/systemdlogtracker/Sender.java
@@ -34,7 +34,7 @@ public class Sender implements Runnable {
         String url = "https://discord.com/api/channels/%s/messages".formatted(Main.getConfig().getDiscordChannelId());
         JSONObject object = new JSONObject();
         object.put("content", content);
-        RequestBody requestBody = RequestBody.create(MediaType.get("application/json"), object.toString());
+        RequestBody requestBody = RequestBody.create(object.toString(), MediaType.get("application/json"));
         Request request = new Request.Builder()
             .url(url)
             .header("Authorization", "Bot " + Main.getConfig().getDiscordToken())
@@ -74,7 +74,7 @@ public class Sender implements Runnable {
         String url = Main.getConfig().getDiscordWebhookUrl();
         JSONObject object = new JSONObject();
         object.put("content", content);
-        RequestBody requestBody = RequestBody.create(MediaType.get("application/json"), object.toString());
+        RequestBody requestBody = RequestBody.create(object.toString(), MediaType.get("application/json"));
         Request request = new Request.Builder()
             .url(url)
             .post(requestBody)
@@ -113,7 +113,7 @@ public class Sender implements Runnable {
         String url = Main.getConfig().getSlackWebhookUrl();
         JSONObject object = new JSONObject();
         object.put("text", content);
-        RequestBody requestBody = RequestBody.create(MediaType.get("application/json"), object.toString());
+        RequestBody requestBody = RequestBody.create(object.toString(), MediaType.get("application/json"));
         Request request = new Request.Builder()
             .url(url)
             .post(requestBody)


### PR DESCRIPTION
This PR adds the ability to filter messages based on strings specified in the `filteredWords` array within the config. This is disabled by default, and can be enabled per the English README