### PR TITLE
ci: changed to $GITHUB_OUTPUT from set-output

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -26,7 +26,7 @@ jobs:
 
     - name: Set SHORT_SHA
       id: vars
-      run: echo "::set-output name=SHORT_SHA::$(git rev-parse --short HEAD)"
+      run: echo "SHORT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
     - name: Create a Release
       if: github.event_name == 'push' || github.ref == 'refs/heads/master'


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/