### PR TITLE
fix(deps): use okhttp-jvm artifact for okhttp 5.x on Maven

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,8 +53,8 @@
     <dependencies>
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>okhttp</artifactId>
-            <version>4.12.0</version>
+            <artifactId>okhttp-jvm</artifactId>
+            <version>5.4.0</version>
         </dependency>
         <dependency>
             <groupId>org.json</groupId>


### PR DESCRIPTION
## 概要

Renovate PR #54 (okhttp `4.12.0` → `5.4.0`) の Maven ビルド失敗 (`package okhttp3 does not exist`) を解消するための修正です。

## 背景 / 根本原因

okhttp 5.x では `com.squareup.okhttp3:okhttp` 成果物が JVM / Android バリアントに分割されました。素の `okhttp` jar は実クラスを含まないスタブ (5.4.0 では 754 バイト、`okhttp3` クラス 0 個) となり、Gradle Module Metadata (`.module`) 経由で `okhttp-jvm` へリダイレクトする仕組みに変わっています。

Maven は Gradle Module Metadata を解釈しないため、`okhttp` を指定しても実クラスが classpath に載らず、`Sender.java` のコンパイルが `package okhttp3 does not exist` で失敗します。

## 修正内容

`pom.xml` の依存 `artifactId` を `okhttp` → `okhttp-jvm` に変更し、version を `5.4.0` に更新しました。

`okhttp-jvm:5.4.0` には `okhttp3` パッケージの実クラス (329 個) が含まれ、コードが使用する API (`RequestBody.create(String, MediaType)`、`MediaType.get(String)`、`Request.Builder` の `url`/`header`/`post`/`build`) はいずれも存在するため、ソースコードの変更は不要です。

## 備考

- この修正は Renovate PR #54 のブランチには手を加えず、独立した PR として作成しています。
- 送信元は upstream への直接 push 権限がないため、fork (`akubiusa/SystemdLogTracker`) からの cross-repo PR です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)